### PR TITLE
Set DB to provisioned and designate primary and replica instances.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_rds_cluster" "postgres_cluster" {
   cluster_identifier      = "aurora-cluster-mdm"
   engine                  = "aurora-postgresql"
   engine_mode             = "provisioned"
-  availability_zones      = [var.az_west_a, "eu-west-2b", "eu-west-2c"]
+  availability_zones      = [var.az_west_a, var.az_west_b, var.az_west_c]
   database_name           = var.db_name
   master_username         = var.db_username
   master_password         = var.db_password

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,11 +15,6 @@ output "database_endpoint" {
   value       = aws_rds_cluster_instance.postgres_primary_instance[0].endpoint
 }
 
-output "database_is_writable" {
-  description = "Whether the database is writable"
-  value       = aws_rds_cluster_instance.postgres_primary_instance[0].writer
-}
-
 output "secondary_database_endpoint" {
   description = "The endpoint of secondary database"
   value       = aws_rds_cluster_instance.postgres_secondary_instance[0].endpoint

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,6 +15,11 @@ output "database_endpoint" {
   value       = aws_rds_cluster_instance.postgres_primary_instance[0].endpoint
 }
 
+output "database_is_writable" {
+  description = "Whether the database is writable"
+  value       = aws_rds_cluster_instance.postgres_primary_instance[0].writer
+}
+
 output "secondary_database_endpoint" {
   description = "The endpoint of secondary database"
   value       = aws_rds_cluster_instance.postgres_secondary_instance[0].endpoint

--- a/variables.tf
+++ b/variables.tf
@@ -90,3 +90,9 @@ variable "az_west_b" {
   type        = string
   default     = "eu-west-2b"
 }
+
+variable "az_west_c" {
+  description = "aws availability zone region 2C"
+  type        = string
+  default     = "eu-west-2c"
+}


### PR DESCRIPTION
- Fixes Availability Zones issue, always specify 3 so that the DB does not need to be rebuilt every-time.
- Fixes issue where main branch of mdm-docker would not build properly.
- Fixes issue where DB was specified as "global" and reverting to "provisioned" forcing rebuild.